### PR TITLE
enable persistent rate

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -309,7 +309,7 @@ func connectEphemeral(addrport string) error {
 
 	connTotal := connectRate * int32(duration.Seconds())
 	tr := rate.Every(time.Second / time.Duration(connectRate))
-	limiter := rate.NewLimiter(tr, int(float64(connectRate)*15/100)) // allow 15% burst
+	limiter := rate.NewLimiter(tr, int(connectRate))
 
 	var wg sync.WaitGroup
 	cause := make(chan error, 1)
@@ -358,7 +358,7 @@ func connectUDP(addrport string) error {
 
 	connTotal := connectRate * int32(duration.Seconds())
 	tr := rate.Every(time.Second / time.Duration(connectRate))
-	limiter := rate.NewLimiter(tr, int(float64(connectRate)*15/100)) // allow 15% burst
+	limiter := rate.NewLimiter(tr, int(connectRate))
 
 	bufUDPPool := sync.Pool{
 		New: func() interface{} { return make([]byte, UDPPacketSize) },

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -126,12 +126,12 @@ func runConnectCmd(cmd *cobra.Command, args []string) error {
 			addr := addr
 			eg.Go(func() error {
 				if showOnlyResults {
-					if err := connectAddr(addr); err != nil {
+					if err := connectAddr(ctx, addr); err != nil {
 						return err
 					}
 				} else {
 					runStatLinePrinter(ctx, cmd.OutOrStdout(), addr)
-					if err := connectAddr(addr); err != nil {
+					if err := connectAddr(ctx, addr); err != nil {
 						return err
 					}
 				}
@@ -154,21 +154,21 @@ func runConnectCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func connectAddr(addr string) error {
+func connectAddr(ctx context.Context, addr string) error {
 	switch protocol {
 	case "tcp":
 		switch connectFlavor {
 		case flavorPersistent:
-			if err := connectPersistent(addr); err != nil {
+			if err := connectPersistent(ctx, addr); err != nil {
 				return err
 			}
 		case flavorEphemeral:
-			if err := connectEphemeral(addr); err != nil {
+			if err := connectEphemeral(ctx, addr); err != nil {
 				return err
 			}
 		}
 	case "udp":
-		if err := connectUDP(addr); err != nil {
+		if err := connectUDP(ctx, addr); err != nil {
 			return err
 		}
 	}
@@ -240,8 +240,8 @@ func updateStat(addr string, n time.Duration) {
 	is.Update(n)
 }
 
-func connectPersistent(addrport string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
+func connectPersistent(ctx context.Context, addrport string) error {
+	ctx, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 
 	bufTCPPool := sync.Pool{
@@ -303,8 +303,8 @@ func connectPersistent(addrport string) error {
 	return <-cause
 }
 
-func connectEphemeral(addrport string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
+func connectEphemeral(ctx context.Context, addrport string) error {
+	ctx, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 
 	connTotal := connectRate * int32(duration.Seconds())
@@ -352,8 +352,8 @@ func connectEphemeral(addrport string) error {
 	return <-cause
 }
 
-func connectUDP(addrport string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
+func connectUDP(ctx context.Context, addrport string) error {
+	ctx, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 
 	connTotal := connectRate * int32(duration.Seconds())

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -260,6 +260,7 @@ func connectPersistent(addrport string) error {
 				log.Printf("could not dial %q: %s", addrport, err)
 				return
 			}
+			defer conn.Close()
 
 			msgsTotal := connectRate * int32(duration.Seconds())
 			tr := rate.Every(time.Second / time.Duration(connectRate))
@@ -291,11 +292,6 @@ func connectPersistent(addrport string) error {
 					log.Println("%v", err)
 					return
 				}
-			}
-
-			if err := conn.Close(); err != nil {
-				log.Printf("could not close: %s\n", err)
-				return
 			}
 		}()
 	}

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -263,7 +263,7 @@ func connectPersistent(addrport string) error {
 
 			msgsTotal := connectRate * int32(duration.Seconds())
 			tr := rate.Every(time.Second / time.Duration(connectRate))
-			limiter := rate.NewLimiter(tr, int(float64(connectRate)*15/100)) // allow 15% burst
+			limiter := rate.NewLimiter(tr, int(connectRate))
 
 			var j int32
 			for j = 0; j < msgsTotal; j++ {

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -258,8 +258,8 @@ func connectPersistent(ctx context.Context, addrport string) error {
 
 			conn, err := net.Dial("tcp", addrport)
 			if err != nil {
-				log.Printf("could not dial %q: %s", addrport, err)
-				return
+				cause <- xerrors.Errorf("could not dial %q: %w", addrport, err)
+				cancel()
 			}
 			defer conn.Close()
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -118,10 +118,7 @@ func handleConnection(conn net.Conn) error {
 					continue
 				}
 			}
-			if errors.Is(err, net.ErrClosed) {
-				break
-			}
-			continue
+			break
 		}
 	REWRITE:
 		if _, err := conn.Write(buf[:n]); err != nil {
@@ -130,10 +127,7 @@ func handleConnection(conn net.Conn) error {
 					goto REWRITE
 				}
 			}
-			if errors.Is(err, net.ErrClosed) {
-				break
-			}
-			continue
+			break
 		}
 	}
 	return nil


### PR DESCRIPTION
- connect: implement rates of tcp messages on persistent flavor
- serve: fix read blocking
- serve: fix busy read loop
- connect: 15% does not mean anything
- connect: enable to close when errors occur in progress
- connect: enable errors propagate
- connect: propagate context
- connect: propagate dial error
